### PR TITLE
Bug fix in Multiclass attack

### DIFF
--- a/xgbKantchelianAttack.py
+++ b/xgbKantchelianAttack.py
@@ -455,7 +455,7 @@ class xgbMultiClassKantchelianAttack(object):
 					dist = np.linalg.norm(x-adv,ord=self.order)
 					suc = adv_pred != label
 					print('target label {}, adv dist:{}, adv predict:{}, success:{}'.format(l, dist, adv_pred, suc))
-					if dist < min_dist:
+					if suc and (dist < min_dist):
 						final_adv = adv
 						min_dist = dist
 		if self.LP:


### PR DESCRIPTION
Fix bug in finding smallest-distance adv. example in multiclass attack.

On the changed line, the previous condition is `if dist < min_dist`; however we actually want the min-distance example from all successful attacks, instead of all attacks.

I believe that without this update, the code produces bug when running multiclass attacks (for example, on fashion mnist).